### PR TITLE
Make log more friendly for TiDB Cloud es log service

### DIFF
--- a/dbms/src/Storages/Page/V3/PageDirectory.cpp
+++ b/dbms/src/Storages/Page/V3/PageDirectory.cpp
@@ -1223,7 +1223,7 @@ bool PageDirectory::tryDumpSnapshot(const ReadLimiterPtr & read_limiter, const W
         // `being_ref_count` by the function `createSnapshot()`.
         assert(!files_snap.persisted_log_files.empty()); // should not be empty when `needSave` return true
         auto log_num = files_snap.persisted_log_files.rbegin()->log_num;
-        auto identifier = fmt::format("{}_dump_{}", wal->name(), log_num);
+        auto identifier = fmt::format("{}.dump_{}", wal->name(), log_num);
         auto snapshot_reader = wal->createReaderForFiles(identifier, files_snap.persisted_log_files, read_limiter);
         PageDirectoryFactory factory;
         // we just use the `collapsed_dir` to dump edit of the snapshot, should never call functions like `apply` that


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tiflash/issues/5134

Problem Summary:
Now we use `__global__.log_dump_4` as logging identifier, which is not friendly for TiDB Cloud log service. We can not get the logs by filtering `__global__.log`.
https://github.com/pingcap/tiflash/blob/10bcb06bcd379601014c70b6dd9173bb960b3c32/dbms/src/Storages/Page/V3/PageDirectory.cpp#L1226-L1234

Change the identifier format to be `__global__.log.dump_4` is more friendly for log searching

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
